### PR TITLE
Setup GitHub Actions Continuous Integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: cargo build --verbose
+
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
Setting up some basic Continuous Integration before starting to refactor the codebase (#7).

Tests are ran on Ubuntu-22.04 only for now, will set things up on other operating systems later down the road.

References:
- https://doc.rust-lang.org/cargo/guide/continuous-integration.html#github-actions