### PR TITLE
Fix compilation errors on Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "geotiff"
 version = "0.0.1"
+edition = "2018"
 authors = ["Dominik Bucher <dobucher@ethz.ch>"]
 repository = "https://github.com/georust/geotiff"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geotiff"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 authors = ["Dominik Bucher <dobucher@ethz.ch>"]
 repository = "https://github.com/georust/geotiff"
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -28,7 +28,7 @@ impl TIFFReader {
     }
 
     /// Reads the `.tiff` file, starting with the byte order.
-    pub fn read(&self, reader: &mut SeekableReader) -> Result<Box<TIFF>> {
+    pub fn read(&self, reader: &mut dyn SeekableReader) -> Result<Box<TIFF>> {
         match self.read_byte_order(reader)? {
             TIFFByteOrder::LittleEndian => self.read_tiff::<LittleEndian>(reader),
             TIFFByteOrder::BigEndian => self.read_tiff::<BigEndian>(reader),
@@ -36,7 +36,7 @@ impl TIFFReader {
     }
 
     /// Helper function to read the byte order, one of `LittleEndian` or `BigEndian`.
-    pub fn read_byte_order(&self, reader: &mut SeekableReader) -> Result<TIFFByteOrder> {
+    pub fn read_byte_order(&self, reader: &mut dyn SeekableReader) -> Result<TIFFByteOrder> {
         // Bytes 0-1: "II" or "MM"
         // Read and validate ByteOrder
         match TIFFByteOrder::from_u16(reader.read_u16::<LittleEndian>()?) {
@@ -50,7 +50,7 @@ impl TIFFReader {
     ///
     /// This starts by reading the magic number, the IFD offset, the IFDs themselves, and finally,
     /// the image data.
-    fn read_tiff<T: ByteOrder>(&self, reader: &mut SeekableReader) -> Result<Box<TIFF>> {
+    fn read_tiff<T: ByteOrder>(&self, reader: &mut dyn SeekableReader) -> Result<Box<TIFF>> {
         self.read_magic::<T>(reader)?;
         let ifd_offset = self.read_ifd_offset::<T>(reader)?;
         let ifd = self.read_IFD::<T>(reader, ifd_offset)?;
@@ -62,7 +62,7 @@ impl TIFFReader {
     }
 
     /// Reads the magic number, i.e., 42.
-    fn read_magic<T: ByteOrder>(&self, reader: &mut SeekableReader) -> Result<()> {
+    fn read_magic<T: ByteOrder>(&self, reader: &mut dyn SeekableReader) -> Result<()> {
         // Bytes 2-3: 0042
         // Read and validate HeaderMagic
         match reader.read_u16::<T>()? {
@@ -72,7 +72,7 @@ impl TIFFReader {
     }
 
     /// Reads the IFD offset. The first IFD is then read from this position.
-    pub fn read_ifd_offset<T: ByteOrder>(&self, reader: &mut SeekableReader) -> Result<u32> {
+    pub fn read_ifd_offset<T: ByteOrder>(&self, reader: &mut dyn SeekableReader) -> Result<u32> {
         // Bytes 4-7: offset
         // Offset from start of file to first IFD
         let ifd_offset_field = reader.read_u32::<T>()?;
@@ -84,7 +84,7 @@ impl TIFFReader {
     ///
     /// This starts by reading the number of entries, and then the tags within each entry.
     #[allow(non_snake_case)]
-    fn read_IFD<T: ByteOrder>(&self, reader: &mut SeekableReader, ifd_offset: u32) -> Result<IFD> {
+    fn read_IFD<T: ByteOrder>(&self, reader: &mut dyn SeekableReader, ifd_offset: u32) -> Result<IFD> {
         reader.seek(SeekFrom::Start(ifd_offset as u64))?;
         // 2 byte count of IFD entries
         let entry_count = reader.read_u16::<T>()?;
@@ -105,7 +105,7 @@ impl TIFFReader {
     }
 
     /// Reads `n` bytes from a reader into a Vec<u8>.
-    fn read_n(&self, reader: &mut SeekableReader, bytes_to_read: u64) -> Vec<u8> {
+    fn read_n(&self, reader: &mut dyn SeekableReader, bytes_to_read: u64) -> Vec<u8> {
         let mut buf = Vec::with_capacity(bytes_to_read as usize);
         let mut chunk = reader.take(bytes_to_read);
         let status = chunk.read_to_end(&mut buf);
@@ -158,8 +158,12 @@ impl TIFFReader {
     ///
     /// This consists of reading the tag ID, field type, number of values, offset to values. After
     /// decoding the tag and type, the values are retrieved.
-    fn read_tag<Endian: ByteOrder>(&self, ifd_offset: u64, entry_number: usize,
-                                   reader: &mut SeekableReader) -> Result<IFDEntry> {
+    fn read_tag<Endian: ByteOrder>(
+        &self,
+        ifd_offset: u64,
+        entry_number: usize,
+        reader: &mut dyn SeekableReader,
+    ) -> Result<IFDEntry> {
         println!("Reading tag at {}/{}", ifd_offset, entry_number);
         // Seek beginning (as each tag is 12 bytes long).
         reader.seek(SeekFrom::Start(ifd_offset + 12 * entry_number as u64))?;
@@ -228,8 +232,11 @@ impl TIFFReader {
     ///
     /// As for now, the following assumptions are made:
     /// * No compression is used, i.e., CompressionTag == 1.
-    fn read_image_data<Endian: ByteOrder>(&self, reader: &mut SeekableReader,
-                                          ifd: &IFD) -> Result<Vec<Vec<Vec<usize>>>> {
+    fn read_image_data<Endian: ByteOrder>(
+        &self,
+        reader: &mut dyn SeekableReader,
+        ifd: &IFD,
+    ) -> Result<Vec<Vec<Vec<usize>>>> {
         // Image size and depth.
         let image_length = ifd.entries.iter().find(|&e| e.tag == TIFFTag::ImageLengthTag)
             .ok_or(Error::new(ErrorKind::InvalidData, "Image length not found."))?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,13 +1,12 @@
-use std::io::{Result, Error, ErrorKind, Read, Seek, SeekFrom};
-use std::path::Path;
 use std::fs::File;
+use std::io::{Error, ErrorKind, Read, Result, Seek, SeekFrom};
+use std::path::Path;
+
+use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use num::FromPrimitive;
 
-use byteorder::{ReadBytesExt, ByteOrder, BigEndian, LittleEndian};
-
-use lowlevel::{TIFFByteOrder, TIFFTag, BYTE, SBYTE, SHORT, SSHORT, LONG, SLONG, FLOAT,
-               TagType, TagValue, tag_size};
-use tiff::{TIFF, IFD, IFDEntry, decode_tag, decode_tag_type};
+use crate::lowlevel::{tag_size, TIFFByteOrder, TIFFTag, TagType, TagValue};
+use crate::tiff::{decode_tag, decode_tag_type, IFDEntry, IFD, TIFF};
 
 /// A helper trait to indicate that something needs to be seekable and readable.
 pub trait SeekableReader: Seek + Read {}
@@ -15,7 +14,7 @@ pub trait SeekableReader: Seek + Read {}
 impl<T: Seek + Read> SeekableReader for T {}
 
 /// The TIFF reader class that encapsulates all functionality related to reading `.tiff` files.
-/// In particular, this includes reading the TIFF header, the image file directories (IDF), and
+/// In particular, this includes reading the TIFF header, the image file directories (IFD), and
 /// the plain data.
 pub struct TIFFReader;
 

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -1,6 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
+
 use enum_primitive::FromPrimitive;
-use lowlevel::*;
+
+use crate::lowlevel::*;
 
 /// The basic TIFF struct. This includes the header (specifying byte order and IFD offsets) as
 /// well as all the image file directories (IFDs) plus image data.


### PR DESCRIPTION
Most of the original code in this repo (up to commit 7dd9068b7aa9e21b7c50f737a765d9d6d089a79a) was written around 2017 and 2018, and appears to be compiled under Rust edition 2015.

The changes here adds an explicit `edition = "2021"` line to the Cargo.toml file, and fixes a couple of compilation errors due to:
- https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html
- https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html#bare_trait_objects

A few 'unused import' warnings have also been fixed, but I haven't fixed all of them yet to keep the diff in this PR small for easier review.