### PR TITLE
Use tiff Tag enum from tiff crate

### DIFF
--- a/src/geotiff.rs
+++ b/src/geotiff.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use tiff::tags::{Tag, Type};
 
 use crate::lowlevel::*;

--- a/src/geotiff.rs
+++ b/src/geotiff.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use enum_primitive::FromPrimitive;
 use tiff::tags::{Tag, Type};
 
 use crate::lowlevel::*;
@@ -55,45 +54,5 @@ impl IFD {
 
     pub fn get_bytes_per_sample() -> usize {
         3
-    }
-}
-
-/// Validation functions to make sure all the required tags are existing for a certain GeoTiff
-/// image type (e.g., grayscale or RGB image).
-pub fn validate_required_tags_for(typ: &ImageType) -> Option<HashSet<TIFFTag>> {
-    let required_grayscale_tags: HashSet<TIFFTag> = [
-        TIFFTag::ImageWidthTag,
-        TIFFTag::ImageLengthTag,
-        TIFFTag::BitsPerSampleTag,
-        TIFFTag::CompressionTag,
-        TIFFTag::PhotometricInterpretationTag,
-        TIFFTag::StripOffsetsTag,
-        TIFFTag::RowsPerStripTag,
-        TIFFTag::StripByteCountsTag,
-        TIFFTag::XResolutionTag,
-        TIFFTag::YResolutionTag,
-        TIFFTag::ResolutionUnitTag].iter().cloned().collect();
-
-    let required_rgb_image_tags: HashSet<TIFFTag> = [
-        TIFFTag::ImageWidthTag,
-        TIFFTag::ImageLengthTag,
-        TIFFTag::BitsPerSampleTag,
-        TIFFTag::CompressionTag,
-        TIFFTag::PhotometricInterpretationTag,
-        TIFFTag::StripOffsetsTag,
-        TIFFTag::SamplesPerPixelTag,
-        TIFFTag::RowsPerStripTag,
-        TIFFTag::StripByteCountsTag,
-        TIFFTag::XResolutionTag,
-        TIFFTag::YResolutionTag,
-        TIFFTag::ResolutionUnitTag,
-    ].iter().cloned().collect();
-
-    match *typ {
-        ImageType::Bilevel => None,
-        ImageType::Grayscale => None,
-        ImageType::PaletteColour => None,
-        ImageType::RGB => Some(required_rgb_image_tags.difference(&required_grayscale_tags).cloned().collect()),
-        ImageType::YCbCr => None,
     }
 }

--- a/src/geotiff.rs
+++ b/src/geotiff.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use enum_primitive::FromPrimitive;
-use tiff::tags::Type;
+use tiff::tags::{Tag, Type};
 
 use crate::lowlevel::*;
 
@@ -36,7 +36,7 @@ pub struct IFD {
 /// tag values.
 #[derive(Debug)]
 pub struct IFDEntry {
-    pub tag: TIFFTag,
+    pub tag: Tag,
     pub tpe: Type,
     pub count: LONG,
     pub value_offset: LONG,
@@ -56,11 +56,6 @@ impl IFD {
     pub fn get_bytes_per_sample() -> usize {
         3
     }
-}
-
-/// Decodes an u16 value into a TIFFTag.
-pub fn decode_tag(value: u16) -> Option<TIFFTag> {
-    TIFFTag::from_u16(value)
 }
 
 /// Validation functions to make sure all the required tags are existing for a certain GeoTiff

--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use tiff::tags::Type;
 
 // Base types of the TIFF format.
@@ -129,6 +130,7 @@ pub enum ImageOrientation {
 // Baseline Tags
 enum_from_primitive! {
     #[repr(u16)]
+    #[deprecated(since="0.1.0", note="use tiff::tags::Tag instead")]
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub enum TIFFTag {
 


### PR DESCRIPTION
Refactor to use [`tiff::tags::Tag`](https://docs.rs/tiff/0.9.1/tiff/tags/enum.Tag.html) instead of the in-house `crate::lowlevel::TIFFTag` enum.

Breaking backward compatibility by:
- Removing the `decode_tag` function, use [`tiff::tags::Tag::from_u16`](https://docs.rs/tiff/0.9.1/tiff/tags/enum.Tag.html#method.from_u16) instead.
- Removing `validate_required_tags_for` function, no direct replacement, but this should really be handled upstream by the image-tiff crate.

Deprecation warnings on:
- `TIFFTag` enum. Will remove once all of the tag variants been migrated upstream, xref https://github.com/image-rs/image-tiff/issues/47.

Part of #7.