### PR TITLE
WIP: Use tiff ifd Value enum from tiff crate

### DIFF
--- a/src/geotiff.rs
+++ b/src/geotiff.rs
@@ -1,3 +1,4 @@
+use tiff::decoder::ifd::Value;
 use tiff::tags::{Tag, Type};
 
 use crate::lowlevel::*;
@@ -37,7 +38,7 @@ pub struct IFDEntry {
     pub tpe: Type,
     pub count: LONG,
     pub value_offset: LONG,
-    pub value: Vec<TagValue>,
+    pub value: Vec<Value>,
 }
 
 /// Implementations for the IFD struct.


### PR DESCRIPTION
Refactor to use [`tiff::decoder::ifd::Value`](https://docs.rs/tiff/0.9.1/tiff/decoder/ifd/enum.Value.html) instead of the in-house `crate::lowlevel::TagValue` enum.

Part of #7.