### PR TITLE
Update description and badge in main README.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "geotiff"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "num-traits",
  "tiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "geotiff"
+description = "A GeoTIFF library for Rust"
 version = "0.0.1"
 edition = "2021"
 authors = ["Dominik Bucher <dobucher@ethz.ch>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geotiff"
 description = "A GeoTIFF library for Rust"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["Dominik Bucher <dobucher@ethz.ch>"]
 repository = "https://github.com/georust/geotiff"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A GeoTIFF library for Rust
 
-![Version](https://img.shields.io/badge/version-v0.0.2-red.svg)
+[![geotiff on crates.io](https://img.shields.io/crates/v/geotiff.svg)](https://crates.io/crates/geotiff)
 
 > [!IMPORTANT]
 > This crate is currently undergoing a significant refactoring process to be built on

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# A TIFF Library for Rust
+# A GeoTIFF library for Rust
 
 ![Version](https://img.shields.io/badge/version-v0.0.2-red.svg)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+//! A [GeoTIFF](https://www.ogc.org/standard/geotiff) library for Rust
 use std::any::type_name;
 use std::io::{Read, Seek};
 


### PR DESCRIPTION
Heading in main README.md now says GeoTIFF instead of TIFF. Badge now points to https://crates.io/crates/geotiff (and have updated version in Cargo.toml to match the 0.0.2 version on crates.io).