### PR TITLE
Set MSRV to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
     "Gunnar Schulze <gunnar.schulze@gmail.com>"
 ]
 repository = "https://github.com/georust/geotiff"
+rust-version = "1.70"
 
 [dependencies]
 delaunator = { version = "1.0", optional = true }


### PR DESCRIPTION
Set minimum supported Rust version (MSRV). Determined using [`cargo msrv find --write-msrv`](https://gribnau.dev/cargo-msrv/releases/v0.15_v0.16_highlights.html#cargo-msrv-find---write-msrv).

Output from `cargo msrv list`:

```
  [Meta]   cargo-msrv 0.18.3

  ╭────────┬─────────────────────────────────────────────────────────────╮
  │ MSRV   │ Dependency                                                  │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.70.0 │ geotiff, num_enum, geo-types, num_enum_derive               │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.67.0 │ proc-macro-crate                                            │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.65.0 │ toml_edit, winnow, toml_datetime                            │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.63.0 │ indexmap, hashbrown                                         │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.61.0 │ tiff, jpeg-decoder, syn, memchr                             │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.60.0 │ num-traits                                                  │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.56.1 │ flate2                                                      │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.56.0 │ quote, proc-macro2, serde_derive                            │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.31.0 │ serde, unicode-ident                                        │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.6.0  │ equivalent                                                  │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │ 1.0.0  │ autocfg                                                     │
  ├────────┼─────────────────────────────────────────────────────────────┤
  │        │ weezl, libm, approx, miniz_oxide, crc32fast, adler2, cfg-if │
  ╰────────┴─────────────────────────────────────────────────────────────╯
```


- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
