### PR TITLE
make DecoderExt and CoordinateTransform::transform_to_raster public

### DIFF
--- a/src/coordinate_transform.rs
+++ b/src/coordinate_transform.rs
@@ -152,7 +152,7 @@ impl CoordinateTransform {
         }
     }
 
-    pub(super) fn transform_to_raster(&self, coord: &Coord) -> Coord {
+    pub fn transform_to_raster(&self, coord: &Coord) -> Coord {
         match self {
             CoordinateTransform::AffineTransform {
                 inverse_transform, ..

--- a/src/decoder_ext.rs
+++ b/src/decoder_ext.rs
@@ -7,7 +7,7 @@ use tiff::TiffResult;
 use crate::coordinate_transform::CoordinateTransform;
 use crate::geo_key_directory::GeoKeyDirectory;
 
-pub(super) trait DecoderExt {
+pub trait DecoderExt {
     fn coordinate_transform(&mut self) -> TiffResult<Option<CoordinateTransform>>;
 
     fn geo_key_directory(&mut self) -> TiffResult<GeoKeyDirectory>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ use tiff::decoder::{Decoder, DecodingResult};
 use tiff::tags::Tag;
 use tiff::TiffResult;
 
-pub use crate::geo_key_directory::{GeoKeyDirectory, RasterType};
 pub use crate::coordinate_transform::CoordinateTransform;
 pub use crate::decoder_ext::DecoderExt;
+pub use crate::geo_key_directory::{GeoKeyDirectory, RasterType};
 use crate::raster_data::RasterData;
 
 mod coordinate_transform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,16 @@ use tiff::tags::Tag;
 use tiff::TiffResult;
 
 pub use crate::geo_key_directory::*;
-
-use crate::coordinate_transform::*;
-use crate::decoder_ext::*;
+pub use crate::coordinate_transform::*;
+pub use crate::decoder_ext::*;
 use crate::raster_data::*;
 
 mod coordinate_transform;
 mod decoder_ext;
 mod geo_key_directory;
 mod raster_data;
+
+pub use decoder_ext::DecoderExt;
 
 macro_rules! unwrap_primitive_type {
     ($result: expr, $actual: ty, $expected: ty) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,17 +8,15 @@ use tiff::decoder::{Decoder, DecodingResult};
 use tiff::tags::Tag;
 use tiff::TiffResult;
 
-pub use crate::geo_key_directory::*;
-pub use crate::coordinate_transform::*;
-pub use crate::decoder_ext::*;
-use crate::raster_data::*;
+pub use crate::geo_key_directory::{GeoKeyDirectory, RasterType};
+pub use crate::coordinate_transform::CoordinateTransform;
+pub use crate::decoder_ext::DecoderExt;
+use crate::raster_data::RasterData;
 
 mod coordinate_transform;
 mod decoder_ext;
 mod geo_key_directory;
 mod raster_data;
-
-pub use decoder_ext::DecoderExt;
 
 macro_rules! unwrap_primitive_type {
     ($result: expr, $actual: ty, $expected: ty) => {


### PR DESCRIPTION
- [x ] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

I have a rather niche case opening files that are too big to fit into memory, so I have to read them with the low-level tiff api. However the geotiff metadata decoding is still a nice feature to use.